### PR TITLE
[#2] 회원가입 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# mysql config
+application-mysql.properties
+
 # Compiled class file
 *.class
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,37 +1,38 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.3'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.kboticketing'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.security:spring-security-crypto'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kboticketing/kboticketing/controller/UserController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.kboticketing.kboticketing.controller;
+
+import com.kboticketing.kboticketing.dto.UserDto;
+import com.kboticketing.kboticketing.service.UserService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * @author hazel
+ */
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("signup")
+    public void signUp(@RequestBody @Valid UserDto userDto) {
+        userService.signUp(userDto);
+    }
+}
+

--- a/src/main/java/com/kboticketing/kboticketing/dao/UserMapper.java
+++ b/src/main/java/com/kboticketing/kboticketing/dao/UserMapper.java
@@ -1,0 +1,15 @@
+package com.kboticketing.kboticketing.dao;
+
+import com.kboticketing.kboticketing.domain.User;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * @author hazel
+ */
+@Mapper
+public interface UserMapper {
+
+    void insertUser(User user);
+
+    User selectUserByEmail(String email);
+}

--- a/src/main/java/com/kboticketing/kboticketing/domain/User.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/User.java
@@ -1,0 +1,30 @@
+package com.kboticketing.kboticketing.domain;
+
+import com.kboticketing.kboticketing.utils.enums.Role;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author hazel
+ */
+@Getter
+@ToString
+public class User {
+
+    private long userId;
+    private String name;
+    private final String email;
+    private final String password;
+    private final Role role;
+    private final LocalDateTime createdAt;
+
+    public User(String name, String email, String password, Role role, LocalDateTime createdAt) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/dto/UserDto.java
+++ b/src/main/java/com/kboticketing/kboticketing/dto/UserDto.java
@@ -1,0 +1,39 @@
+package com.kboticketing.kboticketing.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+import lombok.Getter;
+
+
+/**
+ * @author hazel
+ */
+
+@Getter
+public final class UserDto {
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    private final String name;
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 아닙니다.")
+    private final String email;
+    @NotBlank(message = "인증코드를 입력해주세요.")
+    private final String code;
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,20}", message = "비밀번호는 영문자와 숫자,특수문자가 최소 1개 이상씩 포함된 8~20자로 입력해주세요.")
+    private final String password;
+    @NotBlank(message = "확인할 비밀번호를 입력해주세요.")
+    private final String confirmedPassword;
+
+    public UserDto(String name, String email, String code, String password,
+        String confirmedPassword) {
+
+        this.name = name;
+        this.email = email;
+        this.code = code;
+        this.password = password;
+        this.confirmedPassword = confirmedPassword;
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/service/UserService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/UserService.java
@@ -1,0 +1,55 @@
+package com.kboticketing.kboticketing.service;
+
+import com.kboticketing.kboticketing.dao.UserMapper;
+import com.kboticketing.kboticketing.domain.User;
+import com.kboticketing.kboticketing.dto.UserDto;
+import com.kboticketing.kboticketing.utils.enums.Role;
+import com.kboticketing.kboticketing.utils.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+import static com.kboticketing.kboticketing.utils.exception.ErrorCode.EMAIL_ALREADY_EXISTS;
+import static com.kboticketing.kboticketing.utils.exception.ErrorCode.PASSWORD_MISMATCH;
+
+/**
+ * @author hazel
+ */
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserMapper userMapper;
+
+    public void signUp(UserDto userDto) {
+        //todo 인증번호 확인 로직 -> 인증번호 API 작업 후 작업 예정
+
+        if (!userDto.getPassword()
+                    .equals(userDto.getConfirmedPassword())) {
+            throw new CustomException(PASSWORD_MISMATCH);
+        }
+
+        User registeredUser = userMapper.selectUserByEmail(userDto.getEmail());
+        if (registeredUser != null) {
+            throw new CustomException(EMAIL_ALREADY_EXISTS);
+        }
+
+        User user = toDomain(userDto);
+        userMapper.insertUser(user);
+    }
+
+    public User toDomain(UserDto userDto) {
+        String encodedPassword = encryptPassword(userDto.getPassword());
+        LocalDateTime now = LocalDateTime.now();
+        return new User(userDto.getName(), userDto.getEmail(), encodedPassword, Role.USER, now);
+    }
+
+    public String encryptPassword(String password) {
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        return passwordEncoder.encode(password);
+    }
+}
+
+

--- a/src/main/java/com/kboticketing/kboticketing/utils/enums/Role.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/enums/Role.java
@@ -1,0 +1,11 @@
+package com.kboticketing.kboticketing.utils.enums;
+
+import lombok.Getter;
+
+/**
+ * @author hazel
+ */
+@Getter
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/kboticketing/kboticketing/utils/exception/CustomException.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/exception/CustomException.java
@@ -11,5 +11,4 @@ import lombok.Getter;
 public class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
-
 }

--- a/src/main/java/com/kboticketing/kboticketing/utils/exception/ErrorCode.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/exception/ErrorCode.java
@@ -12,9 +12,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     /* 400 BAD_REQUEST : 잘못된 요청 */
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, 4000, "입력값이 유효하지 않습니다");
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다"),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "두 비밀번호가 일치하지 않습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.");
 
     private final HttpStatus httpStatus;
-    private final int code;
     private final String message;
 }

--- a/src/main/java/com/kboticketing/kboticketing/utils/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.kboticketing.kboticketing.utils.exception;
 
 import com.kboticketing.kboticketing.utils.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,20 +20,36 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+
     @ExceptionHandler(value = CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e, HttpServletRequest request) {
-        log.error("url : {}, handleCustomException throw CustomException : {}", request.getRequestURI(), e.getErrorCode());
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e,
+        HttpServletRequest request) {
+
+        log.error("url : {}, handleCustomException throw CustomException : {}, Error Message: {}",
+            request.getRequestURI(), e.getErrorCode(), e.getErrorCode()
+                                                        .getMessage());
+
         return ErrorResponse.toResponseEntity(e.getErrorCode());
     }
 
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e, HttpServletRequest request) {
-        log.error("url : {},  handleValidationException throw CustomException : {}", request.getRequestURI(), e.getMessage());
+    public ResponseEntity<ErrorResponse> handleValidationException(
+        MethodArgumentNotValidException e, HttpServletRequest request) {
+
+        log.error("url : {},  handleValidationException throw CustomException : {}",
+            request.getRequestURI(), e.getMessage());
+
         BindingResult bindingResult = e.getBindingResult();
         FieldError firstError = bindingResult.getFieldError();
         String defaultMessage = firstError.getDefaultMessage();
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).
-                body(ErrorResponse.builder().code(400).message(defaultMessage).timestamp(System.currentTimeMillis()).build());
-    }
 
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).
+                             body(ErrorResponse.builder()
+                                               .message(defaultMessage)
+                                               .timestamp(now.format(formatter))
+                                               .build());
+    }
 }

--- a/src/main/java/com/kboticketing/kboticketing/utils/response/ErrorResponse.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/response/ErrorResponse.java
@@ -1,6 +1,8 @@
 package com.kboticketing.kboticketing.utils.response;
 
 import com.kboticketing.kboticketing.utils.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.ResponseEntity;
@@ -8,18 +10,22 @@ import org.springframework.http.ResponseEntity;
 /**
  * @author hazel
  */
-
 @Getter
 @Builder
 public class ErrorResponse {
-    private final int code;
+
     private final String message;
-    private final long timestamp;
+    private final String timestamp;
 
     public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode errorCode) {
-        return ResponseEntity.status(errorCode.getHttpStatus()).
-                body(ErrorResponse.builder().code(errorCode.getCode()).message(errorCode.getMessage()).timestamp(System.currentTimeMillis()).build());
+
+        LocalDateTime now = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                             .body(ErrorResponse.builder()
+                                                .message(errorCode.getMessage())
+                                                .timestamp(now.format(formatter))
+                                                .build());
     }
-
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=kbo-ticketing
+# mysql
+spring.profiles.include=mysql
+# mybatis
+mybatis.mapper-locations=classpath:mapper/**/*.xml

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.kboticketing.kboticketing.dao.UserMapper">
+    <insert id="insertUser" parameterType="com.kboticketing.kboticketing.domain.User">
+        INSERT INTO users (name, `email`, password, role, created_at)
+        VALUES (#{name}, #{email}, #{password}, #{role}, #{createdAt})
+    </insert>
+
+    <select id="selectUserByEmail" resultType="com.kboticketing.kboticketing.domain.User">
+        SELECT name, email, password, role, created_at
+        FROM users
+        WHERE email = #{email}
+    </select>
+
+</mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--mybatis 설정파일 -->
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <!-- 설정 옵션 추가-->
+    <mappers>
+        <!--MyBatis 매퍼파일 등록 그리고 해당 매퍼파일에는 쿼리를 정의. -->
+        <mapper resource="UserMapper.xml"/>
+    </mappers>
+</configuration>

--- a/src/test/java/com/kboticketing/kboticketing/controller/UserControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/UserControllerTest.java
@@ -1,0 +1,68 @@
+package com.kboticketing.kboticketing.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kboticketing.kboticketing.dto.UserDto;
+import com.kboticketing.kboticketing.service.UserService;
+import com.kboticketing.kboticketing.utils.exception.CustomException;
+import com.kboticketing.kboticketing.utils.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * @author hazel
+ */
+@WebMvcTest(UserController.class)
+@ExtendWith(MockitoExtension.class)
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    UserService userService;
+
+    @Test
+    @DisplayName("[ERROR] 회원가입 비밀번호 일치 테스트")
+    void signUpPasswordMatchTest() throws Exception {
+
+        //given
+        UserDto userDto = new UserDto("홍길동", "aaaa@naver.com", "123123", "Pa$$w0rd!", "123123");
+        String json = new ObjectMapper().writeValueAsString(userDto);
+
+        willThrow(new CustomException(ErrorCode.PASSWORD_MISMATCH))
+            .given(userService)
+            .signUp(any());
+
+        //when, then
+        mockMvc.perform(post("/signup")
+                   .content(json)
+                   .contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[ERROR] 회원가입 비밀번호 유효성 검사 테스트")
+    void signUpDTOValidTest() throws Exception {
+
+        //given
+        UserDto userDto = new UserDto("원빈", "aaaa@naver.com", "123123", "1234", "1234");
+        String json = new ObjectMapper().writeValueAsString(userDto);
+
+        //when, then
+        mockMvc.perform(post("/signup")
+                   .content(json)
+                   .contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/kboticketing/kboticketing/service/UserServiceTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/service/UserServiceTest.java
@@ -1,0 +1,85 @@
+package com.kboticketing.kboticketing.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+import com.kboticketing.kboticketing.dao.UserMapper;
+import com.kboticketing.kboticketing.domain.User;
+import com.kboticketing.kboticketing.dto.UserDto;
+import com.kboticketing.kboticketing.utils.enums.Role;
+import com.kboticketing.kboticketing.utils.exception.CustomException;
+import com.kboticketing.kboticketing.utils.exception.ErrorCode;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author hazel
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    UserService userService;
+    @Mock
+    UserMapper userMapper;
+
+    @Test
+    @DisplayName("[SUCCESS] 회원가입 성공 테스트")
+    public void signUpSuccessTest() {
+
+        // given
+        UserDto userDto = new UserDto("홍길동", "aaa@naver.com", "123123", "123123", "123123");
+        given(userMapper.selectUserByEmail(any())).willReturn(null);
+
+        //when, then : 아무런 예외를 던지지 않음.
+        assertDoesNotThrow(() -> userService.signUp(userDto));
+    }
+
+    @Test
+    @DisplayName("[ERROR] 회원가입 비밀번호 일치 테스트")
+    public void signUpPasswordMismatchTest() {
+
+        //given
+        UserDto userDto = new UserDto("홍길동", "aaa@naver.com", "123123", "123123", "000000");
+
+        // when
+        CustomException customException = assertThrows(CustomException.class, () -> {
+            userService.signUp(userDto);
+        });
+
+        //then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.PASSWORD_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("[ERROR] 회원가입 이메일 존재 여부 확인 테스트")
+    public void signUpEmailCheckTest() {
+
+        //given
+        UserDto userDto = new UserDto("홍길동", "aaa@naver.com", "123123", "123123", "123123");
+        User user = new User("홍길동", "aaa@naver.com", "123123", Role.USER, LocalDateTime.now());
+        BDDMockito.given(userMapper.selectUserByEmail(userDto.getEmail()))
+                  .willReturn(user);
+
+        //when
+        CustomException customException = assertThrows(CustomException.class, () -> {
+            userService.signUp(userDto);
+        });
+
+        //then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.EMAIL_ALREADY_EXISTS);
+    }
+}
+
+
+
+


### PR DESCRIPTION
## 관련이슈 
- #2 
- #3 

## 작업내용 
- `Google-Java-Style-Format` 적용
-  `ErrorResponse` `timestamp`의  타입을 `string`으로 변경 후 `date format` 적용
-  `ErrorCode` 의 code 필드 삭제
-  회원가입시 비밀번호는 암호화는 `BCryptPasswordEncoder` 사용
-   유닛테스트는 `controller`, `service` 레이어 작성


## 참고사항
- 이전 #4 리뷰 내용 같이 반영하였습니다.
- 회원가입 시 인증번호를 확인하는 로직이 빠져있습니다. 다음 API 구현 후 바로 추가하겠습니다.
- 후에 Jacoco 추가 예정입니다. 

## 궁금한점 
