### PR TITLE
[#8] 인증번호 전송 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # mysql config
 application-mysql.properties
+# redis
+application-redis.properties
+#email-info
+application-email.properties
 
 # Compiled class file
 *.class

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kboticketing/kboticketing/config/EmailConfig.java
+++ b/src/main/java/com/kboticketing/kboticketing/config/EmailConfig.java
@@ -1,0 +1,48 @@
+package com.kboticketing.kboticketing.config;
+
+import java.util.Properties;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+/**
+ * @author hazel
+ */
+@Configuration
+@PropertySource("classpath:application-email.properties")
+@ConfigurationProperties(prefix = "spring.mail")
+@Setter
+@Getter
+public class EmailConfig {
+
+    private String user;
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost("smtp.naver.com");
+        javaMailSender.setUsername(user);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(465);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp"); // 프로토콜
+        properties.setProperty("mail.smtp.auth", "true"); // smtp 인증
+        properties.setProperty("mail.smtp.starttls.enable", "true"); // smtp strattles 사용
+        properties.setProperty("mail.smtp.ssl.trust", "smtp.naver.com"); // ssl 인증 서버 (smtp 서버명)
+        properties.setProperty("mail.smtp.ssl.enable", "true"); // ssl 사용
+        return properties;
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/config/RedisConfig.java
+++ b/src/main/java/com/kboticketing/kboticketing/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.kboticketing.kboticketing.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+/**
+ * @author hazel
+ */
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(
+            redisStandaloneConfiguration); //레디스와의 연결 진행
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/controller/UserController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.kboticketing.kboticketing.controller;
 
+import com.kboticketing.kboticketing.dto.EmailRequestDto;
 import com.kboticketing.kboticketing.dto.UserDto;
 import com.kboticketing.kboticketing.service.UserService;
 import jakarta.validation.Valid;
@@ -20,6 +21,11 @@ public class UserController {
     @PostMapping("users")
     public void signUp(@RequestBody @Valid UserDto userDto) {
         userService.signUp(userDto);
+    }
+
+    @PostMapping("verification-code")
+    public void sendVerificationCode(@RequestBody @Valid EmailRequestDto emailRequestDto) {
+        userService.sendVerificationCode(emailRequestDto);
     }
 }
 

--- a/src/main/java/com/kboticketing/kboticketing/dto/EmailRequestDto.java
+++ b/src/main/java/com/kboticketing/kboticketing/dto/EmailRequestDto.java
@@ -1,0 +1,22 @@
+package com.kboticketing.kboticketing.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * @author hazel
+ */
+@Getter
+public class EmailRequestDto {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 아닙니다.")
+    private final String email;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public EmailRequestDto(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/service/UserService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/UserService.java
@@ -49,22 +49,18 @@ public class UserService {
 
     public void sendVerificationCode(EmailRequestDto emailRequestDto) {
         Boolean hasKey = redisTemplate.hasKey(emailRequestDto.getEmail());
-        if (hasKey == null) {
-            throw new CustomException(ErrorCode.FAIL_SEND_EMAIL);
-        }
-
         if (hasKey) {
-            throw new CustomException(ErrorCode.TOO_FREQUENT_VERIFICATION_REQUEST);
+            throw new CustomException(ErrorCode.FREQUENT_VERIFICATION_REQUEST);
         }
 
         String verificationCode = createRandomNumber();
         log.info("{}'s verification code  = {}", emailRequestDto.getEmail(), verificationCode);
 
-        emailUtil.sendEmail(verificationCode, emailRequestDto.getEmail());
-
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         valueOperations.set(emailRequestDto.getEmail(), verificationCode, 5,
             TimeUnit.MINUTES);
+
+        emailUtil.sendEmail(verificationCode, emailRequestDto.getEmail());
     }
 }
 

--- a/src/main/java/com/kboticketing/kboticketing/service/UserService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/UserService.java
@@ -2,15 +2,19 @@ package com.kboticketing.kboticketing.service;
 
 import com.kboticketing.kboticketing.dao.UserMapper;
 import com.kboticketing.kboticketing.domain.User;
+import com.kboticketing.kboticketing.dto.EmailRequestDto;
 import com.kboticketing.kboticketing.dto.UserDto;
-import com.kboticketing.kboticketing.utils.enums.Role;
+import com.kboticketing.kboticketing.utils.EmailUtils;
 import com.kboticketing.kboticketing.utils.exception.CustomException;
+import com.kboticketing.kboticketing.utils.exception.ErrorCode;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-
+import static com.kboticketing.kboticketing.utils.NumberUtils.createRandomNumber;
 import static com.kboticketing.kboticketing.utils.exception.ErrorCode.EMAIL_ALREADY_EXISTS;
 import static com.kboticketing.kboticketing.utils.exception.ErrorCode.PASSWORD_MISMATCH;
 
@@ -19,9 +23,12 @@ import static com.kboticketing.kboticketing.utils.exception.ErrorCode.PASSWORD_M
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 
     private final UserMapper userMapper;
+    private final EmailUtils emailUtil;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public void signUp(UserDto userDto) {
         //todo 인증번호 확인 로직 -> 인증번호 API 작업 후 작업 예정
@@ -38,6 +45,26 @@ public class UserService {
 
         User user = userDto.toUser();
         userMapper.insert(user);
+    }
+
+    public void sendVerificationCode(EmailRequestDto emailRequestDto) {
+        Boolean hasKey = redisTemplate.hasKey(emailRequestDto.getEmail());
+        if (hasKey == null) {
+            throw new CustomException(ErrorCode.FAIL_SEND_EMAIL);
+        }
+
+        if (hasKey) {
+            throw new CustomException(ErrorCode.TOO_FREQUENT_VERIFICATION_REQUEST);
+        }
+
+        String verificationCode = createRandomNumber();
+        log.info("{}'s verification code  = {}", emailRequestDto.getEmail(), verificationCode);
+
+        emailUtil.sendEmail(verificationCode, emailRequestDto.getEmail());
+
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(emailRequestDto.getEmail(), verificationCode, 5,
+            TimeUnit.MINUTES);
     }
 }
 

--- a/src/main/java/com/kboticketing/kboticketing/utils/EmailUtils.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/EmailUtils.java
@@ -1,0 +1,55 @@
+package com.kboticketing.kboticketing.utils;
+
+import com.kboticketing.kboticketing.utils.exception.CustomException;
+import com.kboticketing.kboticketing.utils.exception.ErrorCode;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+/**
+ * @author hazel
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class EmailUtils {
+
+    @Value("${spring.mail.user}")
+    private String user;
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    public void sendEmail(String verificationCode, String toEmail) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false,
+                "UTF-8");
+            mimeMessageHelper.setTo(toEmail);
+            mimeMessageHelper.setSubject("KBO-TICKETING 회원가입 인증번호입니다.");
+            mimeMessageHelper.setFrom(user);
+            mimeMessageHelper.setText(setContext(verificationCode, "email"), true);
+
+            //메일 전송
+            javaMailSender.send(mimeMessage);
+            log.info(
+                "Successfully sent verification code. Recipient: {}, Sender: {}, code: {}",
+                toEmail, user, verificationCode);
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.FAIL_SEND_EMAIL);
+        }
+    }
+
+    public String setContext(String code, String type) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process(type, context);
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/utils/NumberUtils.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/NumberUtils.java
@@ -1,0 +1,22 @@
+package com.kboticketing.kboticketing.utils;
+
+import java.security.SecureRandom;
+
+/**
+ * @author hazel
+ */
+public class NumberUtils {
+
+    private static final int CODE_LENGTH = 6;
+
+    public static String createRandomNumber() {
+        StringBuilder code = new StringBuilder();
+        SecureRandom secureRandom = new SecureRandom();
+
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            int randomNumber = secureRandom.nextInt(10); //0부터 9까지 랜덤한 정수 반환
+            code.append(randomNumber);
+        }
+        return code.toString();
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/utils/NumberUtils.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/NumberUtils.java
@@ -8,10 +8,10 @@ import java.security.SecureRandom;
 public class NumberUtils {
 
     private static final int CODE_LENGTH = 6;
+    private static final SecureRandom secureRandom = new SecureRandom();
 
     public static String createRandomNumber() {
         StringBuilder code = new StringBuilder();
-        SecureRandom secureRandom = new SecureRandom();
 
         for (int i = 0; i < CODE_LENGTH; i++) {
             int randomNumber = secureRandom.nextInt(10); //0부터 9까지 랜덤한 정수 반환

--- a/src/main/java/com/kboticketing/kboticketing/utils/exception/ErrorCode.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/exception/ErrorCode.java
@@ -14,7 +14,11 @@ public enum ErrorCode {
     /* 400 BAD_REQUEST : 잘못된 요청 */
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다"),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "두 비밀번호가 일치하지 않습니다."),
-    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다.");
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
+    TOO_FREQUENT_VERIFICATION_REQUEST(HttpStatus.BAD_REQUEST, "잦은 인증번호 요청은 불가능합니다."),
+
+    /* 500 INTERNAL_SERVER_ERROR : 서버 오류 */
+    FAIL_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/kboticketing/kboticketing/utils/exception/ErrorCode.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다"),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "두 비밀번호가 일치하지 않습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    TOO_FREQUENT_VERIFICATION_REQUEST(HttpStatus.BAD_REQUEST, "잦은 인증번호 요청은 불가능합니다."),
+    FREQUENT_VERIFICATION_REQUEST(HttpStatus.BAD_REQUEST, "잦은 인증번호 요청은 불가능합니다."),
 
     /* 500 INTERNAL_SERVER_ERROR : 서버 오류 */
     FAIL_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다.");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 spring.application.name=kbo-ticketing
-# mysql
-spring.profiles.include=mysql
+spring.profiles.include=mysql,redis
 # mybatis
 mybatis.mapper-locations=classpath:mapper/**/*.xml

--- a/src/main/resources/templates/email.html
+++ b/src/main/resources/templates/email.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+</head>
+
+<body>
+<div style="margin:100px;">
+  <h1> 안녕하세요.</h1>
+  <h1> 야구 예매 플랫폼 KBO-TICKEING 입니다. </h1>
+  <br>
+  <p> 아래 코드를 회원가입 창으로 돌아가 입력해주세요.</p>
+  <br>
+
+  <div align="center" style="border:1px solid rgba(9,0,0,0.9); font-family:verdana;">
+    <h3 style="color:rgba(12,3,3,0.9)"> 회원가입 인증 코드 입니다. </h3>
+    <div style="font-size:130%" th:text="${code}"></div>
+  </div>
+  <br/>
+</div>
+
+</body>
+</html>

--- a/src/test/java/com/kboticketing/kboticketing/controller/UserControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.kboticketing.kboticketing.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kboticketing.kboticketing.dto.EmailRequestDto;
 import com.kboticketing.kboticketing.dto.UserDto;
 import com.kboticketing.kboticketing.service.UserService;
 import com.kboticketing.kboticketing.utils.exception.CustomException;
@@ -33,7 +34,7 @@ public class UserControllerTest {
     UserService userService;
 
     @Test
-    @DisplayName("[ERROR] 회원가입 비밀번호 일치 테스트")
+    @DisplayName("[FAIL] 회원가입 비밀번호 일치 테스트")
     void signUpPasswordMatchTest() throws Exception {
 
         //given
@@ -52,7 +53,7 @@ public class UserControllerTest {
     }
 
     @Test
-    @DisplayName("[ERROR] 회원가입 비밀번호 유효성 검사 테스트")
+    @DisplayName("[FAIL] 회원가입 비밀번호 유효성 검사 테스트")
     void signUpDTOValidTest() throws Exception {
 
         //given
@@ -79,6 +80,49 @@ public class UserControllerTest {
                    .content(json)
                    .contentType(MediaType.APPLICATION_JSON))
                .andExpect(status().isOk());
+    }
 
+    @Test
+    @DisplayName("[SUCCESS] 이메일 인증 성공 테스트")
+    void sendVerificationTest() throws Exception {
+
+        //given
+        EmailRequestDto emailRequestDto = new EmailRequestDto("waithjno@gmail.com");
+        String json = new ObjectMapper().writeValueAsString(emailRequestDto);
+
+        //when,then
+        mockMvc.perform(post("/verification-code")
+                   .content(json)
+                   .contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[FAIL] 이메일 입력 테스트")
+    void sendVerificationEmailInputTest() throws Exception {
+        //given
+        EmailRequestDto emailRequestDto = new EmailRequestDto("");
+        String json = new ObjectMapper().writeValueAsString(emailRequestDto);
+
+        //when, then
+        mockMvc.perform(post("/verification-code")
+                   .content(json)
+                   .contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[FAIL] 이메일 유효성 검증 태스트")
+    void sendVerificationEmailValidTest() throws Exception {
+
+        //given
+        EmailRequestDto emailRequestDto = new EmailRequestDto("aaa");
+        String json = new ObjectMapper().writeValueAsString(emailRequestDto);
+
+        //when, then
+        mockMvc.perform(post("/verification-code")
+                   .content(json)
+                   .contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/kboticketing/kboticketing/service/UserServiceTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/service/UserServiceTest.java
@@ -8,11 +8,15 @@ import static org.mockito.BDDMockito.*;
 
 import com.kboticketing.kboticketing.dao.UserMapper;
 import com.kboticketing.kboticketing.domain.User;
+import com.kboticketing.kboticketing.dto.EmailRequestDto;
 import com.kboticketing.kboticketing.dto.UserDto;
+import com.kboticketing.kboticketing.utils.EmailUtils;
+import com.kboticketing.kboticketing.utils.NumberUtils;
 import com.kboticketing.kboticketing.utils.enums.Role;
 import com.kboticketing.kboticketing.utils.exception.CustomException;
 import com.kboticketing.kboticketing.utils.exception.ErrorCode;
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +24,8 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 /**
  * @author hazel
@@ -31,6 +37,12 @@ class UserServiceTest {
     UserService userService;
     @Mock
     UserMapper userMapper;
+    @Mock
+    RedisTemplate<String, String> redisTemplate;
+    @Mock
+    ValueOperations<String, String> valueOperations;
+    @Mock
+    EmailUtils emailUtils;
 
     @Test
     @DisplayName("[SUCCESS] 회원가입 성공 테스트")
@@ -45,7 +57,7 @@ class UserServiceTest {
     }
 
     @Test
-    @DisplayName("[ERROR] 회원가입 비밀번호 일치 테스트")
+    @DisplayName("[FAIL] 회원가입 비밀번호 일치 테스트")
     public void signUpPasswordMismatchTest() {
 
         //given
@@ -61,7 +73,7 @@ class UserServiceTest {
     }
 
     @Test
-    @DisplayName("[ERROR] 회원가입 이메일 존재 여부 확인 테스트")
+    @DisplayName("[FAIL] 회원가입 이메일 존재 여부 확인 테스트")
     public void signUpEmailCheckTest() {
 
         //given
@@ -77,6 +89,62 @@ class UserServiceTest {
 
         //then
         assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.EMAIL_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 이메일 인증 성공 테스트")
+    public void sendVerificationSuccessTest() {
+
+        //given
+        EmailRequestDto emailRequestDto = new EmailRequestDto("hi@naver.com");
+        given(redisTemplate.hasKey(anyString())).willReturn(false);
+
+        mockStatic(NumberUtils.class);
+        given(NumberUtils.createRandomNumber()).willReturn("123456");
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        //when
+        userService.sendVerificationCode(emailRequestDto);
+
+        //then
+        verify(emailUtils).sendEmail(anyString(), anyString());
+        verify(valueOperations).set(emailRequestDto.getEmail(), "123456", 5, TimeUnit.MINUTES);
+    }
+
+    @Test
+    @DisplayName("[FAIL] 이메일 인증 잦은 요청 테스트")
+    public void sendVerificationAgainFailTest() {
+
+        //given
+        EmailRequestDto emailRequestDto = new EmailRequestDto("111@naver.com");
+        given(redisTemplate.hasKey(anyString())).willReturn(true);
+
+        // when
+        CustomException customException = assertThrows(CustomException.class, () -> {
+            userService.sendVerificationCode(emailRequestDto);
+        });
+
+        //then
+        assertThat(customException.getErrorCode()).isEqualTo(
+            ErrorCode.TOO_FREQUENT_VERIFICATION_REQUEST);
+    }
+
+    @Test
+    @DisplayName("[FAIL] 이메일 인증 테스트")
+    public void sendVerificationFailTest() {
+
+        //given
+        EmailRequestDto emailRequestDto = new EmailRequestDto("111@naver.com");
+        given(redisTemplate.hasKey(anyString())).willReturn(null);
+
+        // when
+        CustomException customException = assertThrows(CustomException.class, () -> {
+            userService.sendVerificationCode(emailRequestDto);
+        });
+
+        //then
+        assertThat(customException.getErrorCode()).isEqualTo(
+            ErrorCode.FAIL_SEND_EMAIL);
     }
 }
 

--- a/src/test/java/com/kboticketing/kboticketing/service/UserServiceTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/service/UserServiceTest.java
@@ -11,12 +11,10 @@ import com.kboticketing.kboticketing.domain.User;
 import com.kboticketing.kboticketing.dto.EmailRequestDto;
 import com.kboticketing.kboticketing.dto.UserDto;
 import com.kboticketing.kboticketing.utils.EmailUtils;
-import com.kboticketing.kboticketing.utils.NumberUtils;
 import com.kboticketing.kboticketing.utils.enums.Role;
 import com.kboticketing.kboticketing.utils.exception.CustomException;
 import com.kboticketing.kboticketing.utils.exception.ErrorCode;
 import java.time.LocalDateTime;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -98,9 +96,6 @@ class UserServiceTest {
         //given
         EmailRequestDto emailRequestDto = new EmailRequestDto("hi@naver.com");
         given(redisTemplate.hasKey(anyString())).willReturn(false);
-
-        mockStatic(NumberUtils.class);
-        given(NumberUtils.createRandomNumber()).willReturn("123456");
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
         //when
@@ -108,7 +103,7 @@ class UserServiceTest {
 
         //then
         verify(emailUtils).sendEmail(anyString(), anyString());
-        verify(valueOperations).set(emailRequestDto.getEmail(), "123456", 5, TimeUnit.MINUTES);
+        verify(valueOperations).set(anyString(), anyString(), anyLong(), any());
     }
 
     @Test
@@ -126,25 +121,7 @@ class UserServiceTest {
 
         //then
         assertThat(customException.getErrorCode()).isEqualTo(
-            ErrorCode.TOO_FREQUENT_VERIFICATION_REQUEST);
-    }
-
-    @Test
-    @DisplayName("[FAIL] 이메일 인증 테스트")
-    public void sendVerificationFailTest() {
-
-        //given
-        EmailRequestDto emailRequestDto = new EmailRequestDto("111@naver.com");
-        given(redisTemplate.hasKey(anyString())).willReturn(null);
-
-        // when
-        CustomException customException = assertThrows(CustomException.class, () -> {
-            userService.sendVerificationCode(emailRequestDto);
-        });
-
-        //then
-        assertThat(customException.getErrorCode()).isEqualTo(
-            ErrorCode.FAIL_SEND_EMAIL);
+            ErrorCode.FREQUENT_VERIFICATION_REQUEST);
     }
 }
 

--- a/src/test/java/com/kboticketing/kboticketing/utils/NumberUtilsTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/utils/NumberUtilsTest.java
@@ -1,0 +1,26 @@
+package com.kboticketing.kboticketing.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+
+/**
+ * @author hazel
+ */
+class NumberUtilsTest {
+
+    @RepeatedTest(10)
+    @DisplayName("랜덤 넘버 생성 반복 테스트")
+    void createRandomNumberRepeatTest() {
+        int numberLength = 6;
+
+        String randomNumber1 = NumberUtils.createRandomNumber();
+        String randomNumber2 = NumberUtils.createRandomNumber();
+
+        assertEquals(numberLength, randomNumber1.length());
+        assertEquals(numberLength, randomNumber2.length());
+
+        assertNotEquals(randomNumber1, randomNumber2);
+    }
+}


### PR DESCRIPTION
## 관련이슈 
- #8 

## 작업내용
- `redis` 설정 및 세팅
- `NumberUtils` 추가 
- `javaMailSender`을 이용해 메일 전송기능 구현 
-  `redis` `TTL` 설정해 인증번호 저장 기능 구현 
- `user controller`, `service`,  `numberUtils` 유닛 테스트 작성


## 참고사항 

## 궁금한점 
- 테스트케이스를 잘 짜고있는지 의문이 듭니다 😂 
- 정적 메소드의 테스트 케이스 사용이 궁금합니다. 현재 `mockito-inline`을 사용하여 구현했습니다. 
- utils클래스는 다 정적 메소드로만 만드는 것이 맞는지 궁금합니다. 
- 현재 mysql , redis, mail 정보를 현재 `.gitignore`로 추가하였는데 변경해야할지 궁금합니다.