### PR TITLE
[#9] 인증번호 확인 API 구현

### DIFF
--- a/src/main/java/com/kboticketing/kboticketing/controller/UserController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/UserController.java
@@ -2,6 +2,7 @@ package com.kboticketing.kboticketing.controller;
 
 import com.kboticketing.kboticketing.dto.EmailRequestDto;
 import com.kboticketing.kboticketing.dto.UserDto;
+import com.kboticketing.kboticketing.dto.VerificationCodeDto;
 import com.kboticketing.kboticketing.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,11 @@ public class UserController {
     @PostMapping("verification-code")
     public void sendVerificationCode(@RequestBody @Valid EmailRequestDto emailRequestDto) {
         userService.sendVerificationCode(emailRequestDto);
+    }
+
+    @PostMapping("verification-code-validation")
+    public void checkVerificationCode(@RequestBody @Valid VerificationCodeDto verificationCodeDto) {
+        userService.checkVerificationCode(verificationCodeDto);
     }
 }
 

--- a/src/main/java/com/kboticketing/kboticketing/dto/VerificationCodeDto.java
+++ b/src/main/java/com/kboticketing/kboticketing/dto/VerificationCodeDto.java
@@ -1,0 +1,21 @@
+package com.kboticketing.kboticketing.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+@Getter
+@RequiredArgsConstructor
+public class VerificationCodeDto {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 아닙니다.")
+    private final String email;
+
+    @NotBlank(message = "인증번호를 입력해주세요.")
+    private final String verificationCode;
+}

--- a/src/main/java/com/kboticketing/kboticketing/service/UserService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/UserService.java
@@ -4,9 +4,11 @@ import com.kboticketing.kboticketing.dao.UserMapper;
 import com.kboticketing.kboticketing.domain.User;
 import com.kboticketing.kboticketing.dto.EmailRequestDto;
 import com.kboticketing.kboticketing.dto.UserDto;
+import com.kboticketing.kboticketing.dto.VerificationCodeDto;
 import com.kboticketing.kboticketing.utils.EmailUtils;
 import com.kboticketing.kboticketing.utils.exception.CustomException;
 import com.kboticketing.kboticketing.utils.exception.ErrorCode;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +33,10 @@ public class UserService {
     private final RedisTemplate<String, String> redisTemplate;
 
     public void signUp(UserDto userDto) {
-        //todo 인증번호 확인 로직 -> 인증번호 API 작업 후 작업 예정
+        Boolean hasKey = redisTemplate.hasKey(userDto.getEmail());
+        if (Boolean.FALSE.equals(hasKey)) {
+            throw new CustomException(ErrorCode.REQUEST_VERIFICATION_FIRST);
+        }
 
         if (!userDto.getPassword()
                     .equals(userDto.getConfirmedPassword())) {
@@ -61,6 +66,19 @@ public class UserService {
             TimeUnit.MINUTES);
 
         emailUtil.sendEmail(verificationCode, emailRequestDto.getEmail());
+    }
+
+    public void checkVerificationCode(VerificationCodeDto verificationCodeDto) {
+        Boolean hasKey = redisTemplate.hasKey(verificationCodeDto.getEmail());
+        if (Boolean.FALSE.equals(hasKey)) {
+            throw new CustomException(ErrorCode.REQUEST_VERIFICATION_FIRST);
+        }
+
+        String storedVerificationCode = redisTemplate.opsForValue()
+                                                     .get(verificationCodeDto.getEmail());
+        if (!Objects.equals(verificationCodeDto.getVerificationCode(), storedVerificationCode)) {
+            throw new CustomException(ErrorCode.WRONG_VERIFICATION_CODE);
+        }
     }
 }
 

--- a/src/main/java/com/kboticketing/kboticketing/utils/exception/ErrorCode.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "두 비밀번호가 일치하지 않습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     FREQUENT_VERIFICATION_REQUEST(HttpStatus.BAD_REQUEST, "잦은 인증번호 요청은 불가능합니다."),
+    REQUEST_VERIFICATION_FIRST(HttpStatus.BAD_REQUEST, "인증을 먼저 진행해주세요."),
+    WRONG_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 다릅니다."),
 
     /* 500 INTERNAL_SERVER_ERROR : 서버 오류 */
     FAIL_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다.");

--- a/src/test/java/com/kboticketing/kboticketing/controller/UserControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.kboticketing.kboticketing.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kboticketing.kboticketing.dto.EmailRequestDto;
 import com.kboticketing.kboticketing.dto.UserDto;
+import com.kboticketing.kboticketing.dto.VerificationCodeDto;
 import com.kboticketing.kboticketing.service.UserService;
 import com.kboticketing.kboticketing.utils.exception.CustomException;
 import com.kboticketing.kboticketing.utils.exception.ErrorCode;
@@ -112,7 +113,7 @@ public class UserControllerTest {
     }
 
     @Test
-    @DisplayName("[FAIL] 이메일 유효성 검증 태스트")
+    @DisplayName("[FAIL] 이메일 유효성 검증 테스트")
     void sendVerificationEmailValidTest() throws Exception {
 
         //given
@@ -121,6 +122,39 @@ public class UserControllerTest {
 
         //when, then
         mockMvc.perform(post("/verification-code")
+                   .content(json)
+                   .contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 인증번호 확인 테스트")
+    void checkVerificationCodeTest() throws Exception {
+
+        //given
+        VerificationCodeDto verificationCodeDto = new VerificationCodeDto("aaaa@naver.com",
+            "123123");
+        String json = new ObjectMapper().writeValueAsString(verificationCodeDto);
+
+        //when, then
+        mockMvc.perform(post("/verification-code-validation")
+                   .content(json)
+                   .contentType(MediaType.APPLICATION_JSON))
+               .andExpect(status().isOk());
+    }
+
+
+    @Test
+    @DisplayName("[FAIL] 인증번호 미입력 테스트")
+    public void checkVerificationCodeValidationTest() throws Exception {
+
+        //given
+        VerificationCodeDto verificationCodeDto = new VerificationCodeDto("aaaa@naver.com",
+            "");
+        String json = new ObjectMapper().writeValueAsString(verificationCodeDto);
+
+        //when, then
+        mockMvc.perform(post("/verification-code-validation")
                    .content(json)
                    .contentType(MediaType.APPLICATION_JSON))
                .andExpect(status().isBadRequest());


### PR DESCRIPTION
## 관련이슈 
- #9 

## 작업내용
- 인증번호 확인 API 구현
- `user controller`, `service` 유닛 테스트 작성
- 회원가입 시 인증번호 확인 로직 추가

## 참고사항

## 궁금한점 
