### PR TITLE
[#14] 팀 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kboticketing/kboticketing/controller/TeamController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/TeamController.java
@@ -1,0 +1,26 @@
+package com.kboticketing.kboticketing.controller;
+
+import com.kboticketing.kboticketing.domain.Team;
+import com.kboticketing.kboticketing.service.TeamService;
+import com.kboticketing.kboticketing.utils.response.CommonResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author hazel
+ */
+@RestController
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @GetMapping("teams")
+    public ResponseEntity<CommonResponse> getTeams() {
+        List<Team> teams = teamService.getTeams();
+        return ResponseEntity.ok(CommonResponse.ok(teams));
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/dao/TeamMapper.java
+++ b/src/main/java/com/kboticketing/kboticketing/dao/TeamMapper.java
@@ -1,0 +1,15 @@
+package com.kboticketing.kboticketing.dao;
+
+import com.kboticketing.kboticketing.domain.Team;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * @author hazel
+ */
+@Mapper
+public interface TeamMapper {
+
+    List<Team> selectTeams();
+
+}

--- a/src/main/java/com/kboticketing/kboticketing/domain/Team.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/Team.java
@@ -1,0 +1,15 @@
+package com.kboticketing.kboticketing.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+@RequiredArgsConstructor
+@Getter
+public class Team {
+
+    private final Integer teamId;
+    private final String name;
+}

--- a/src/main/java/com/kboticketing/kboticketing/service/TeamService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/TeamService.java
@@ -1,0 +1,21 @@
+package com.kboticketing.kboticketing.service;
+
+import com.kboticketing.kboticketing.dao.TeamMapper;
+import com.kboticketing.kboticketing.domain.Team;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author hazel
+ */
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamMapper teamMapper;
+
+    public List<Team> getTeams() {
+        return teamMapper.selectTeams();
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/utils/response/CommonResponse.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/response/CommonResponse.java
@@ -1,0 +1,21 @@
+package com.kboticketing.kboticketing.utils.response;
+
+import com.kboticketing.kboticketing.utils.DateTimeUtils;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+
+@RequiredArgsConstructor
+@Getter
+public class CommonResponse {
+
+    private final Object data;
+    private final String timestamp;
+
+    public static CommonResponse ok(Object data) {
+        return new CommonResponse(data, DateTimeUtils.getCurrentTime());
+    }
+}

--- a/src/main/resources/mapper/TeamMapper.xml
+++ b/src/main/resources/mapper/TeamMapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.kboticketing.kboticketing.dao.TeamMapper">
+  <select id="selectTeams" resultType="com.kboticketing.kboticketing.domain.Team">
+    SELECT team_id, name
+    FROM teams
+  </select>
+
+</mapper>

--- a/src/test/java/com/kboticketing/kboticketing/controller/TeamControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/TeamControllerTest.java
@@ -1,0 +1,54 @@
+package com.kboticketing.kboticketing.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kboticketing.kboticketing.domain.Team;
+import com.kboticketing.kboticketing.service.TeamService;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+/**
+ * @author hazel
+ */
+@WebMvcTest(TeamController.class)
+@ExtendWith(MockitoExtension.class)
+class TeamControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TeamService teamService;
+
+    @Test
+    @DisplayName("[SUCCESS] 팀 리스트 테스트")
+    public void getTeamsTest() throws Exception {
+
+        //given
+        List<Team> fakeTeams = Arrays.asList(
+            new Team(1, "Team 1"),
+            new Team(2, "Team 2"),
+            new Team(3, "Team 3")
+        );
+        given(teamService.getTeams()).willReturn(fakeTeams);
+
+        //when, then
+        mockMvc.perform(get("/teams"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.data[0].name").value("Team 1"))
+               .andExpect(jsonPath("$.data[1].name").value("Team 2"))
+               .andExpect(jsonPath("$.data[2].name").value("Team 3"));
+    }
+}

--- a/src/test/java/com/kboticketing/kboticketing/service/TeamServiceTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/service/TeamServiceTest.java
@@ -1,0 +1,45 @@
+package com.kboticketing.kboticketing.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.kboticketing.kboticketing.dao.TeamMapper;
+import com.kboticketing.kboticketing.domain.Team;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author hazel
+ */
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    @Mock
+    private TeamMapper teamMapper;
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Test
+    @DisplayName("[SUCCESS] 팀 리스트 테스트")
+    public void getTeamsTest() {
+
+        //given
+        List<Team> fakeTeams = Arrays.asList(
+            new Team(1, "Team 1"),
+            new Team(2, "Team 2"),
+            new Team(3, "Team 3")
+        );
+        given(teamMapper.selectTeams()).willReturn(fakeTeams);
+
+        //when, then
+        assertThat(teamService.getTeams()).isEqualTo(fakeTeams);
+    }
+}


### PR DESCRIPTION
## 관련이슈
- #14 

## 작업내용
- 팀 목록 조회 API 구현
- 공통 응답 포맷 추가 
- `controller`, `service` 성공 유닛 테스트 추가

## 참고사항

## 궁금한점 