### PR TITLE
[#15] 경기 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kboticketing/kboticketing/controller/ScheduleController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/ScheduleController.java
@@ -1,0 +1,29 @@
+package com.kboticketing.kboticketing.controller;
+
+
+import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
+import com.kboticketing.kboticketing.service.ScheduleService;
+import com.kboticketing.kboticketing.utils.response.CommonResponse;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author hazel
+ */
+@RestController
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @GetMapping("schedules")
+    public ResponseEntity<CommonResponse> getSchedules(
+        ScheduleQueryParamDto scheduleQueryParamDto) {
+        ArrayList<ScheduleTeam> schedules = scheduleService.getSchedules(scheduleQueryParamDto);
+        return ResponseEntity.ok(CommonResponse.ok(schedules));
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/dao/ScheduleMapper.java
+++ b/src/main/java/com/kboticketing/kboticketing/dao/ScheduleMapper.java
@@ -1,0 +1,15 @@
+package com.kboticketing.kboticketing.dao;
+
+import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
+import java.util.ArrayList;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * @author hazel
+ */
+@Mapper
+public interface ScheduleMapper {
+
+    ArrayList<ScheduleTeam> selectSchedules(ScheduleQueryParamDto scheduleQueryParamDto);
+}

--- a/src/main/java/com/kboticketing/kboticketing/domain/ScheduleTeam.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/ScheduleTeam.java
@@ -1,0 +1,17 @@
+package com.kboticketing.kboticketing.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+@RequiredArgsConstructor
+@Getter
+public class ScheduleTeam {
+
+    private final Integer scheduleId;
+    private final String scheduleName;
+    private final String stadiumName;
+    private final String date;
+}

--- a/src/main/java/com/kboticketing/kboticketing/dto/ScheduleQueryParamDto.java
+++ b/src/main/java/com/kboticketing/kboticketing/dto/ScheduleQueryParamDto.java
@@ -17,8 +17,8 @@ public class ScheduleQueryParamDto {
     public ScheduleQueryParamDto(Integer teamId, Integer month, Integer day, Integer stadiumId) {
         this.teamId = teamId;
         // month 필드가 null이라면 현재 월 설정
-        this.month = month != null ? month : LocalDateTime.now()
-                                                          .getMonthValue();
+        this.month = month == null ? LocalDateTime.now()
+                                                  .getMonthValue() : month;
         this.day = day;
         this.stadiumId = stadiumId;
     }

--- a/src/main/java/com/kboticketing/kboticketing/dto/ScheduleQueryParamDto.java
+++ b/src/main/java/com/kboticketing/kboticketing/dto/ScheduleQueryParamDto.java
@@ -1,0 +1,25 @@
+package com.kboticketing.kboticketing.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+/**
+ * @author hazel
+ */
+@Getter
+public class ScheduleQueryParamDto {
+
+    private final Integer teamId;
+    private final Integer month;
+    private final Integer day;
+    private final Integer stadiumId;
+
+    public ScheduleQueryParamDto(Integer teamId, Integer month, Integer day, Integer stadiumId) {
+        this.teamId = teamId;
+        // month 필드가 null이라면 현재 월 설정
+        this.month = month != null ? month : LocalDateTime.now()
+                                                          .getMonthValue();
+        this.day = day;
+        this.stadiumId = stadiumId;
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
@@ -1,0 +1,22 @@
+package com.kboticketing.kboticketing.service;
+
+import com.kboticketing.kboticketing.dao.ScheduleMapper;
+import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author hazel
+ */
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final ScheduleMapper scheduleMapper;
+
+    public ArrayList<ScheduleTeam> getSchedules(ScheduleQueryParamDto scheduleQueryParamDto) {
+        return scheduleMapper.selectSchedules(scheduleQueryParamDto);
+    }
+}

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.kboticketing.kboticketing.dao.ScheduleMapper">
+  <select id="selectSchedules" resultType="com.kboticketing.kboticketing.domain.ScheduleTeam">
+    SELECT
+    schedules.schedule_id,
+    schedules.name AS scheduleName,
+    stadium.name AS stadiumName,
+    schedules.date AS date
+    FROM schedules schedules
+    LEFT JOIN
+    stadium ON stadium.stadium_id = schedules.stadium_id
+    <where>
+      <if test="teamId != null">
+        AND home_team_id = #{teamId}
+      </if>
+      <if test="month != null">
+        AND month(date)= #{month}
+      </if>
+      <if test="day != null">
+        AND day(date)= #{day}
+      </if>
+      <if test="stadiumId != null">
+        AND schedules.stadium_id = #{stadiumId}
+      </if>
+    </where>
+  </select>
+</mapper>

--- a/src/test/java/com/kboticketing/kboticketing/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/ScheduleControllerTest.java
@@ -1,0 +1,49 @@
+package com.kboticketing.kboticketing.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import com.kboticketing.kboticketing.service.ScheduleService;
+import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * @author hazel
+ */
+@WebMvcTest(ScheduleController.class)
+@ExtendWith(MockitoExtension.class)
+class ScheduleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("[SUCCESS] 일정 목록 조회 테스트")
+    public void getSchedulesTest() throws Exception {
+
+        //given
+        ArrayList<ScheduleTeam> scheduleTeams = new ArrayList<>();
+        scheduleTeams.add(new ScheduleTeam(1, "LG vs SSG", "잠실종합운동장", "2024-04-01 18:30:00"));
+        given(scheduleService.getSchedules(any())).willReturn(scheduleTeams);
+
+        //when, then
+        mockMvc.perform(get("/schedules"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.data[0].scheduleId").value(scheduleTeams.get(0)
+                                                                              .getScheduleId()));
+    }
+}

--- a/src/test/java/com/kboticketing/kboticketing/service/ScheduleServiceTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/service/ScheduleServiceTest.java
@@ -1,0 +1,42 @@
+package com.kboticketing.kboticketing.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.kboticketing.kboticketing.dao.ScheduleMapper;
+import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.given;
+
+/**
+ * @author hazel
+ */
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+
+    @Mock
+    private ScheduleMapper scheduleMapper;
+
+    @InjectMocks
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("[SUCCESS] 경기 목록 조회 테스트")
+    public void getSchedulesTest() {
+
+        //given
+        ArrayList<ScheduleTeam> scheduleTeams = new ArrayList<>();
+        scheduleTeams.add(new ScheduleTeam(1, "LG vs SSG", "잠실종합운동장", "2024-04-01 18:30:00"));
+        given(scheduleMapper.selectSchedules(any())).willReturn(scheduleTeams);
+
+        //when, then
+        assertThat(scheduleService.getSchedules(any())).isEqualTo(scheduleTeams);
+    }
+}


### PR DESCRIPTION
## 관련 이슈 
- #15 

## 작업 내용 
- 경기 목록 조회 API 구현 
- `schedule controller`, `service` 성공 시 유닛테스트 추가
- 월,  일, 구장별 필터링 기능 추가 
  -  월이 선택되지 않았을때 디폴트로 이번 달 경기목록만 리턴하도록 구현

## 참고사항
- 레디스 캐싱 작업은 기능을 다 구현한 다음에 진행하겠습니다.

## 궁금한 점 or 공부할 내용 🤔
- 테스트 시 실제 dto가 아닌 any()로 설정해야하는이유 
- `ResponseEntity`로 감싸야하는 이유
- mybatis는 어떻게 매핑을 하는가
- 스프링 빈은 어떻게 thread-safe한가 
- dto 필드가 하나일때 역직렬화의 문제점