### PR TITLE
[#18] 경기 정보, 좌석 등급 리스트 API 구현

### DIFF
--- a/src/main/java/com/kboticketing/kboticketing/controller/ScheduleController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/ScheduleController.java
@@ -32,7 +32,7 @@ public class ScheduleController {
         return ResponseEntity.ok(CommonResponse.ok(scheduleService.getSchedule(id)));
     }
 
-    @GetMapping("/schedules/{id}/seat-grade")
+    @GetMapping("/schedules/{id}/seat-grades")
     public ResponseEntity<CommonResponse> getSeatGradeBySchedule(@PathVariable String id) {
         return ResponseEntity.ok(CommonResponse.ok(scheduleService.getSeatGradeBySchedule(id)));
     }

--- a/src/main/java/com/kboticketing/kboticketing/controller/ScheduleController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/ScheduleController.java
@@ -1,6 +1,5 @@
 package com.kboticketing.kboticketing.controller;
 
-
 import com.kboticketing.kboticketing.domain.ScheduleTeam;
 import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
 import com.kboticketing.kboticketing.service.ScheduleService;
@@ -9,6 +8,7 @@ import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -25,5 +25,10 @@ public class ScheduleController {
         ScheduleQueryParamDto scheduleQueryParamDto) {
         ArrayList<ScheduleTeam> schedules = scheduleService.getSchedules(scheduleQueryParamDto);
         return ResponseEntity.ok(CommonResponse.ok(schedules));
+    }
+
+    @GetMapping("/schedules/{id}")
+    public ResponseEntity<CommonResponse> getSchedule(@PathVariable String id) {
+        return ResponseEntity.ok(CommonResponse.ok(scheduleService.getSchedule(id)));
     }
 }

--- a/src/main/java/com/kboticketing/kboticketing/controller/ScheduleController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/ScheduleController.java
@@ -31,4 +31,9 @@ public class ScheduleController {
     public ResponseEntity<CommonResponse> getSchedule(@PathVariable String id) {
         return ResponseEntity.ok(CommonResponse.ok(scheduleService.getSchedule(id)));
     }
+
+    @GetMapping("/schedules/{id}/seat-grade")
+    public ResponseEntity<CommonResponse> getSeatGradeBySchedule(@PathVariable String id) {
+        return ResponseEntity.ok(CommonResponse.ok(scheduleService.getSeatGradeBySchedule(id)));
+    }
 }

--- a/src/main/java/com/kboticketing/kboticketing/dao/ScheduleMapper.java
+++ b/src/main/java/com/kboticketing/kboticketing/dao/ScheduleMapper.java
@@ -1,5 +1,6 @@
 package com.kboticketing.kboticketing.dao;
 
+import com.kboticketing.kboticketing.domain.ScheduleInfo;
 import com.kboticketing.kboticketing.domain.ScheduleTeam;
 import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
 import java.util.ArrayList;
@@ -12,4 +13,6 @@ import org.apache.ibatis.annotations.Mapper;
 public interface ScheduleMapper {
 
     ArrayList<ScheduleTeam> selectSchedules(ScheduleQueryParamDto scheduleQueryParamDto);
+
+    ScheduleInfo selectInfo(String id);
 }

--- a/src/main/java/com/kboticketing/kboticketing/dao/ScheduleMapper.java
+++ b/src/main/java/com/kboticketing/kboticketing/dao/ScheduleMapper.java
@@ -2,6 +2,7 @@ package com.kboticketing.kboticketing.dao;
 
 import com.kboticketing.kboticketing.domain.ScheduleInfo;
 import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import com.kboticketing.kboticketing.domain.SeatGradeBySchedule;
 import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
 import java.util.ArrayList;
 import org.apache.ibatis.annotations.Mapper;
@@ -15,4 +16,6 @@ public interface ScheduleMapper {
     ArrayList<ScheduleTeam> selectSchedules(ScheduleQueryParamDto scheduleQueryParamDto);
 
     ScheduleInfo selectInfo(String id);
+
+    ArrayList<SeatGradeBySchedule> selectSeatGrade(String id);
 }

--- a/src/main/java/com/kboticketing/kboticketing/domain/ScheduleInfo.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/ScheduleInfo.java
@@ -1,0 +1,17 @@
+package com.kboticketing.kboticketing.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+@Getter
+@RequiredArgsConstructor
+public class ScheduleInfo {
+
+    private final Integer scheduleId;
+    private final String scheduleName;
+    private final String date;
+    private final String stadiumName;
+}

--- a/src/main/java/com/kboticketing/kboticketing/domain/SeatGradeBySchedule.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/SeatGradeBySchedule.java
@@ -1,0 +1,18 @@
+package com.kboticketing.kboticketing.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+@Getter
+@RequiredArgsConstructor
+public class SeatGradeBySchedule {
+
+    private final Integer scheduleId;
+    private final Integer seatGradeId;
+    private final String seatGradeName;
+    private final String price;
+    private final String seatRemain;
+}

--- a/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
@@ -1,6 +1,7 @@
 package com.kboticketing.kboticketing.service;
 
 import com.kboticketing.kboticketing.dao.ScheduleMapper;
+import com.kboticketing.kboticketing.domain.ScheduleInfo;
 import com.kboticketing.kboticketing.domain.ScheduleTeam;
 import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
 import java.util.ArrayList;
@@ -18,5 +19,9 @@ public class ScheduleService {
 
     public ArrayList<ScheduleTeam> getSchedules(ScheduleQueryParamDto scheduleQueryParamDto) {
         return scheduleMapper.selectSchedules(scheduleQueryParamDto);
+    }
+
+    public ScheduleInfo getSchedule(String id) {
+        return scheduleMapper.selectInfo(id);
     }
 }

--- a/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
@@ -3,6 +3,7 @@ package com.kboticketing.kboticketing.service;
 import com.kboticketing.kboticketing.dao.ScheduleMapper;
 import com.kboticketing.kboticketing.domain.ScheduleInfo;
 import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import com.kboticketing.kboticketing.domain.SeatGradeBySchedule;
 import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
 import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,9 @@ public class ScheduleService {
 
     public ScheduleInfo getSchedule(String id) {
         return scheduleMapper.selectInfo(id);
+    }
+
+    public ArrayList<SeatGradeBySchedule> getSeatGradeBySchedule(String id) {
+        return scheduleMapper.selectSeatGrade(id);
     }
 }

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -39,4 +39,16 @@
     WHERE schedule_id = #{id};
   </select>
 
+  <select id="selectSeatGrade"
+    resultType="com.kboticketing.kboticketing.domain.SeatGradeBySchedule">
+    SELECT sbs.schedule_id    AS scheduleId,
+           sbs.seat_grade_id  AS seatGradeId,
+           sg.seat_grade_name AS seatGradeName,
+           sg.price,
+           sbs.seat_remain    AS seatRemain
+    FROM seat_by_schedules sbs
+           INNER JOIN seat_grade sg ON sbs.seat_grade_id = sg.seat_grade_id
+    WHERE schedule_id = #{id}
+  </select>
+
 </mapper>

--- a/src/main/resources/mapper/ScheduleMapper.xml
+++ b/src/main/resources/mapper/ScheduleMapper.xml
@@ -27,4 +27,16 @@
       </if>
     </where>
   </select>
+
+  <select id="selectInfo" resultType="com.kboticketing.kboticketing.domain.ScheduleInfo">
+    SELECT schedule_id    AS scheduleId,
+           schedules.name AS scheduleName,
+           schedules.date AS date,
+           stadium.name AS stadiumName
+    FROM schedules schedules
+      INNER JOIN stadium
+    ON schedules.stadium_id = stadium.stadium_id
+    WHERE schedule_id = #{id};
+  </select>
+
 </mapper>

--- a/src/test/java/com/kboticketing/kboticketing/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/ScheduleControllerTest.java
@@ -6,7 +6,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.kboticketing.kboticketing.domain.ScheduleInfo;
 import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import com.kboticketing.kboticketing.domain.SeatGradeBySchedule;
 import com.kboticketing.kboticketing.service.ScheduleService;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
@@ -45,5 +47,39 @@ class ScheduleControllerTest {
                .andExpect(status().isOk())
                .andExpect(jsonPath("$.data[0].scheduleId").value(scheduleTeams.get(0)
                                                                               .getScheduleId()));
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 경기 정보 조회 테스트")
+    public void getScheduleTest() throws Exception {
+
+        //given
+        ScheduleInfo scheduleInfo = new ScheduleInfo(1, "LG vs KT", "2024-03-29 18:30:00",
+            "서울종합운동장 야구장");
+        given(scheduleService.getSchedule(any())).willReturn(scheduleInfo);
+
+        //when,then
+        mockMvc.perform(get("/schedules/1"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.data.scheduleId").value(scheduleInfo.getScheduleId()))
+               .andExpect(jsonPath("$.data.scheduleName").value(scheduleInfo.getScheduleName()));
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 좌석 목록 조회 테스트")
+    public void getSeatGradeByScheduleTest() throws Exception {
+
+        //given
+        ArrayList<SeatGradeBySchedule> seatGradeList = new ArrayList<>();
+        seatGradeList.add(new SeatGradeBySchedule(1, 1, "블루석", "20000", "500"));
+        given(scheduleService.getSeatGradeBySchedule(any())).willReturn(seatGradeList);
+
+        //when,then
+        mockMvc.perform(get("/schedules/1/seat-grade"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.data[0].scheduleId").value(seatGradeList.get(0)
+                                                                              .getScheduleId()))
+               .andExpect(jsonPath("$.data[0].seatGradeId").value(seatGradeList.get(0)
+                                                                               .getSeatGradeId()));
     }
 }

--- a/src/test/java/com/kboticketing/kboticketing/service/ScheduleServiceTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/service/ScheduleServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.kboticketing.kboticketing.dao.ScheduleMapper;
+import com.kboticketing.kboticketing.domain.ScheduleInfo;
 import com.kboticketing.kboticketing.domain.ScheduleTeam;
+import com.kboticketing.kboticketing.domain.SeatGradeBySchedule;
 import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,5 +40,31 @@ class ScheduleServiceTest {
 
         //when, then
         assertThat(scheduleService.getSchedules(any())).isEqualTo(scheduleTeams);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 경기 정보 조회 테스트")
+    public void getScheduleTest() {
+
+        //given
+        ScheduleInfo scheduleInfo = new ScheduleInfo(1, "LG vs KT", "2024-03-29 18:30:00",
+            "서울종합운동장 야구장");
+        given(scheduleMapper.selectInfo(any())).willReturn(scheduleInfo);
+
+        //when, then
+        assertThat(scheduleService.getSchedule(any())).isEqualTo(scheduleInfo);
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 좌석 목록 조회 테스트")
+    public void getSeatGradeTest() {
+
+        //given
+        ArrayList<SeatGradeBySchedule> seatGradeList = new ArrayList<>();
+        seatGradeList.add(new SeatGradeBySchedule(1, 1, "블루석", "20000", "500"));
+        given(scheduleMapper.selectSeatGrade(any())).willReturn(seatGradeList);
+
+        //when, then
+        assertThat(scheduleService.getSeatGradeBySchedule(any())).isEqualTo(seatGradeList);
     }
 }


### PR DESCRIPTION
##  관련이슈 
- #18 

## 작업내용 
- 하나의 API로 데이터를 내려주는것이 아니라  `경기 정보 조회 API`와 `좌석 등급 목록 조회 API`를 분리해 구현. 
   -   좌석 목록에 잔여 수량이 있기 때문에 후에 새로고침 기능을 추가할 가능성 존재함.
   -  재활용 가능성이 존재함.
 - `controller`, `service` 레이어 유닛 테스트 추가 
 
## 참고사항
<img width="529" alt="image" src="https://github.com/f-lab-edu/kbo-ticketing/assets/59499600/98aae25b-e7d0-4b52-b3ef-6ee7e22c4aeb">



