### PR TITLE
[#23] 좌석 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kboticketing/kboticketing/controller/SeatController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/SeatController.java
@@ -1,0 +1,28 @@
+package com.kboticketing.kboticketing.controller;
+
+import com.kboticketing.kboticketing.dto.ReservationSeatDto;
+import com.kboticketing.kboticketing.service.SeatService;
+import com.kboticketing.kboticketing.utils.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author hazel
+ */
+@RestController
+@RequiredArgsConstructor
+public class SeatController {
+
+    private final SeatService seatService;
+
+    @GetMapping("/schedules/{scheduleId}/seat-grades/{seatGradeId}")
+    public ResponseEntity<CommonResponse> getSeatsByGrade(@PathVariable String scheduleId,
+        @PathVariable String seatGradeId) {
+
+        ReservationSeatDto seatsBySeatGrade = seatService.getSeatsByGrade(scheduleId, seatGradeId);
+        return ResponseEntity.ok(CommonResponse.ok(seatsBySeatGrade));
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/controller/SeatController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/SeatController.java
@@ -1,5 +1,6 @@
 package com.kboticketing.kboticketing.controller;
 
+import com.kboticketing.kboticketing.domain.SeatGrade;
 import com.kboticketing.kboticketing.dto.ReservationSeatDto;
 import com.kboticketing.kboticketing.service.SeatService;
 import com.kboticketing.kboticketing.utils.response.CommonResponse;
@@ -24,5 +25,12 @@ public class SeatController {
 
         ReservationSeatDto seatsBySeatGrade = seatService.getSeatsByGrade(scheduleId, seatGradeId);
         return ResponseEntity.ok(CommonResponse.ok(seatsBySeatGrade));
+    }
+
+    @GetMapping("/seat-grades/{id}")
+    public ResponseEntity<CommonResponse> getSeatGrade(@PathVariable String id) {
+
+        SeatGrade seatGrade = seatService.getSeatGrade(id);
+        return ResponseEntity.ok(CommonResponse.ok(seatGrade));
     }
 }

--- a/src/main/java/com/kboticketing/kboticketing/dao/SeatMapper.java
+++ b/src/main/java/com/kboticketing/kboticketing/dao/SeatMapper.java
@@ -1,0 +1,14 @@
+package com.kboticketing.kboticketing.dao;
+
+import com.kboticketing.kboticketing.domain.Reservation;
+import java.util.ArrayList;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * @author hazel
+ */
+@Mapper
+public interface SeatMapper {
+
+    ArrayList<Reservation> selectReservations(String scheduleId, String seatGradeId);
+}

--- a/src/main/java/com/kboticketing/kboticketing/dao/SeatMapper.java
+++ b/src/main/java/com/kboticketing/kboticketing/dao/SeatMapper.java
@@ -1,6 +1,7 @@
 package com.kboticketing.kboticketing.dao;
 
 import com.kboticketing.kboticketing.domain.Reservation;
+import com.kboticketing.kboticketing.domain.SeatGrade;
 import java.util.ArrayList;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -11,4 +12,6 @@ import org.apache.ibatis.annotations.Mapper;
 public interface SeatMapper {
 
     ArrayList<Reservation> selectReservations(String scheduleId, String seatGradeId);
+
+    SeatGrade selectSeatGrade(String id);
 }

--- a/src/main/java/com/kboticketing/kboticketing/domain/Reservation.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/Reservation.java
@@ -1,0 +1,15 @@
+package com.kboticketing.kboticketing.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+@RequiredArgsConstructor
+@Getter
+public class Reservation {
+
+    private final int seatNumber;
+
+}

--- a/src/main/java/com/kboticketing/kboticketing/domain/SeatGrade.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/SeatGrade.java
@@ -1,0 +1,18 @@
+package com.kboticketing.kboticketing.domain;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+public class SeatGrade {
+
+    private final Integer seatGradeId;
+    private final String seatGradeName;
+    private final String seatCount;
+}

--- a/src/main/java/com/kboticketing/kboticketing/dto/ReservationSeatDto.java
+++ b/src/main/java/com/kboticketing/kboticketing/dto/ReservationSeatDto.java
@@ -1,0 +1,19 @@
+package com.kboticketing.kboticketing.dto;
+
+import java.util.ArrayList;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+public class ReservationSeatDto {
+
+    private final ArrayList<Integer> seatNumbers;
+
+}

--- a/src/main/java/com/kboticketing/kboticketing/service/SeatService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/SeatService.java
@@ -1,0 +1,31 @@
+package com.kboticketing.kboticketing.service;
+
+import com.kboticketing.kboticketing.dto.ReservationSeatDto;
+import com.kboticketing.kboticketing.dao.SeatMapper;
+import com.kboticketing.kboticketing.domain.Reservation;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author hazel
+ */
+@Service
+@RequiredArgsConstructor
+public class SeatService {
+
+    private final SeatMapper seatMapper;
+
+    public ReservationSeatDto getSeatsByGrade(String scheduleId, String seatGradeId) {
+
+        ArrayList<Reservation> reservations = seatMapper.selectReservations(scheduleId,
+            seatGradeId);
+
+        ArrayList<Integer> reservedSeat = new ArrayList<>();
+        for (Reservation reservation : reservations) {
+            reservedSeat.add(reservation.getSeatNumber());
+        }
+
+        return new ReservationSeatDto(reservedSeat);
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/service/SeatService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/SeatService.java
@@ -1,5 +1,6 @@
 package com.kboticketing.kboticketing.service;
 
+import com.kboticketing.kboticketing.domain.SeatGrade;
 import com.kboticketing.kboticketing.dto.ReservationSeatDto;
 import com.kboticketing.kboticketing.dao.SeatMapper;
 import com.kboticketing.kboticketing.domain.Reservation;
@@ -27,5 +28,9 @@ public class SeatService {
         }
 
         return new ReservationSeatDto(reservedSeat);
+    }
+
+    public SeatGrade getSeatGrade(String id) {
+        return seatMapper.selectSeatGrade(id);
     }
 }

--- a/src/main/resources/mapper/SeatMapper.xml
+++ b/src/main/resources/mapper/SeatMapper.xml
@@ -10,4 +10,10 @@
       AND seat_grade_id = #{seatGradeId};
   </select>
 
+  <select id="selectSeatGrade" resultType="com.kboticketing.kboticketing.domain.SeatGrade">
+    SELECT seat_grade_id, seat_grade_name, seat_count
+    FROM seat_grade
+    WHERE seat_grade_id = #{id};
+  </select>
+
 </mapper>

--- a/src/main/resources/mapper/SeatMapper.xml
+++ b/src/main/resources/mapper/SeatMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.kboticketing.kboticketing.dao.SeatMapper">
+
+  <select id="selectReservations" resultType="com.kboticketing.kboticketing.domain.Reservation">
+    SELECT seat_number
+    FROM reservations
+    WHERE schedule_id = #{scheduleId}
+      AND seat_grade_id = #{seatGradeId};
+  </select>
+
+</mapper>

--- a/src/test/java/com/kboticketing/kboticketing/controller/SeatControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/SeatControllerTest.java
@@ -1,0 +1,70 @@
+package com.kboticketing.kboticketing.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.kboticketing.kboticketing.domain.SeatGrade;
+import com.kboticketing.kboticketing.dto.ReservationSeatDto;
+import com.kboticketing.kboticketing.service.SeatService;
+import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * @author hazel
+ */
+@WebMvcTest(SeatController.class)
+@ExtendWith(MockitoExtension.class)
+class SeatControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    SeatService seatService;
+
+    @Test
+    @DisplayName("[SUCCESS]예약 좌석 목록 조회 테스트")
+    public void getSeatsByGradeTest() throws Exception {
+
+        //given
+        ReservationSeatDto reservationSeatDto = new ReservationSeatDto(new ArrayList<>());
+        reservationSeatDto.getSeatNumbers()
+                          .add(1);
+        reservationSeatDto.getSeatNumbers()
+                          .add(2);
+        given(seatService.getSeatsByGrade(any(), any()))
+            .willReturn(reservationSeatDto);
+
+        //when, then
+        mockMvc.perform(get("/schedules/1/seat-grades/1"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.data.seatNumbers[0]").value(1))
+               .andExpect(jsonPath("$.data.seatNumbers[1]").value(2));
+    }
+
+    @Test
+    @DisplayName("[SUCCESS] 좌석 정보 조회 테스트")
+    public void getSeatGradeTest() throws Exception {
+
+        //given
+        SeatGrade seatGrade = new SeatGrade(1, "블루석 300블럭", "300");
+        given(seatService.getSeatGrade(any())).willReturn(seatGrade);
+
+        //when, then
+        mockMvc.perform(get("/seat-grades/1"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.data.seatGradeId").value(1))
+               .andExpect(jsonPath("$.data.seatGradeName").value("블루석 300블럭"))
+               .andExpect(jsonPath("$.data.seatCount").value("300"));
+    }
+}

--- a/src/test/java/com/kboticketing/kboticketing/service/SeatServiceTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/service/SeatServiceTest.java
@@ -1,0 +1,67 @@
+package com.kboticketing.kboticketing.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+import com.kboticketing.kboticketing.dao.SeatMapper;
+import com.kboticketing.kboticketing.domain.Reservation;
+import com.kboticketing.kboticketing.domain.SeatGrade;
+import com.kboticketing.kboticketing.dto.ReservationSeatDto;
+import java.util.ArrayList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author hazel
+ */
+@ExtendWith(MockitoExtension.class)
+class SeatServiceTest {
+
+    @Mock
+    private SeatMapper seatMapper;
+
+    @InjectMocks
+    private SeatService seatService;
+
+    @Test
+    @DisplayName("[SUCCESS] 예약 좌석 목록 조회 테스트")
+    public void getSeatsByGradeTest() {
+
+        //given
+        ArrayList<Reservation> reservations = new ArrayList<>();
+        reservations.add(new Reservation(1));
+        reservations.add(new Reservation(2));
+        given(seatMapper.selectReservations(any(), any()))
+            .willReturn(reservations);
+
+        ArrayList<Integer> reservedSeat = new ArrayList<>();
+        for (Reservation reservation : reservations) {
+            reservedSeat.add(reservation.getSeatNumber());
+        }
+
+        ReservationSeatDto reservationSeatDto = new ReservationSeatDto(reservedSeat);
+
+        //when, then
+        assertThat(seatService.getSeatsByGrade(any(), any())).usingRecursiveAssertion()
+                                                             .isEqualTo(reservationSeatDto);
+    }
+
+
+    @Test
+    @DisplayName("[SUCCESS]좌석 정보 조회 테스트")
+    public void getSeatGradeTest() {
+
+        //given
+        SeatGrade seatGrade = new SeatGrade(1, "블루석 300블럭", "300");
+        given(seatMapper.selectSeatGrade(any())).willReturn(seatGrade);
+
+        //when,then
+        assertThat(seatService.getSeatGrade(any())).usingRecursiveAssertion()
+                                                   .isEqualTo(seatGrade);
+    }
+}


### PR DESCRIPTION
## 관련 이슈 
- #23 
- #24 


## 작업내용
1.   좌석 정보가 재활용성이 있을 것으로 예상하여 API 2개로 나눠서 구현

1.1  `예약 완료 좌석 목록 조회 API` 
```java
{
    "data": {
        "seatNumbers": [
            1,
            2,
            3,
            4
        ]
    },
    "timestamp": "2024-04-05 16:10:27"
}
``` 
 1.2  `좌석 정보 API` 

```java

{
    "data": {
        "seatGradeId": 1,
        "seatGradeName": "블루석 300블럭",
        "seatCount": "500" //총 좌석 개수
    },
    "timestamp": "2024-04-05 16:09:22"
}

```

2.  `seat controller`, `service` 유닛 테스트
 
## 참고사항 
- #24 의 2번으로 진행했습니다..!
- 좌석 번호를 단순히 1,2,3번 으로 생각하여 설계하였는데 열 번호를 추가해아할지? 추가한다면 어떻게 해야할지 고민중입니당

## 궁금한 점 or 공부할 내용 🤔
1. `SeatService`의  `getSeatsByGrade()`에서 `domain`에서 `dto`로 변환로직의 위치가 올바를까?
2. `getSeatsByGrade()`의  `SeatController` or `ScheduleController` 중 어디에 구현되었어야 할까? 
