### PR TITLE
[#10] jacoco 설정 및 테스트 커버리지 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
 }
 
 group = 'com.kboticketing'
@@ -39,4 +40,56 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+jacocoTestReport { //바이너리 커버리지 결과를 읽기 좋은 형태로 저장
+    dependsOn test
+    reports {
+        xml.required.set(false)
+        csv.required.set(false)
+        html.required.set(true)
+    }
+
+    afterEvaluate { //리포트에서 제외
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            '**/dto/**',
+                            '**/dao/**',
+                            '**/domain/**',
+                            '**/enums/**',
+                            '**/exception/**',
+                            '**/*Application*',
+                            // ...
+                    ])
+                })
+        )
+    }
+    finalizedBy jacocoTestCoverageVerification
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.8  //테스트 커버리지 80
+            }
+
+            excludes = [
+                    '**.*Application',
+                    '**.domain.**',
+                    '**.dto.**'
+            ]
+        }
+    }
 }


### PR DESCRIPTION
## 관련이슈 
- #10  

## 작업 내용
- jacoco 설정 및 테스트 커버리지 확인
    - 현 시점 기준으로 테스트 커버리지 평균 `81%`
<img width="1250" alt="jacoco" src="https://github.com/f-lab-edu/kbo-ticketing/assets/59499600/b1b21ba8-7e58-4076-a93d-eac5e91f2517">

-  라인 커버리지 제한을 80%로 설정해 80%보다 낮으면 build 못하게 설정

## 개선사항 및 추가할 사항
- util 클래스에 unit test가 부족하여 추가할 예정입니다. 