### PR TITLE
[#35] 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    //jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.12.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -78,16 +78,20 @@ jacocoTestReport { //바이너리 커버리지 결과를 읽기 좋은 형태로
 jacocoTestCoverageVerification {
     violationRules {
         rule {
+            element = 'CLASS'
+            enabled = true
             limit {
                 minimum = 0.8  //프로젝트 전체 테스트 커버리지 80
             }
-
             excludes = [
-                    '**.*Application',
-                    '**.domain.**',
-                    '**.dto.**',
-                    '**.enums.**',
-                    '**.response.**',
+                    '*.*Application',
+                    '*.domain.*',
+                    '*.dto.*',
+                    '*.dao.*',
+                    '*.enums.*',
+                    '*.response.*',
+                    '*.exception.*',
+                    '*.config.*',
             ]
         }
     }

--- a/src/main/java/com/kboticketing/kboticketing/config/JwtProperties.java
+++ b/src/main/java/com/kboticketing/kboticketing/config/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.kboticketing.kboticketing.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author hazel
+ */
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@Setter
+public class JwtProperties {
+
+    private String secret;
+}

--- a/src/main/java/com/kboticketing/kboticketing/config/WebConfig.java
+++ b/src/main/java/com/kboticketing/kboticketing/config/WebConfig.java
@@ -1,6 +1,8 @@
 package com.kboticketing.kboticketing.config;
 
-import com.kboticketing.kboticketing.Interceptor.LoginInterceptor;
+import com.kboticketing.kboticketing.interceptor.LoginInterceptor;
+import com.kboticketing.kboticketing.service.JwtService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -9,11 +11,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * @author hazel
  */
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtService jwtService;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new LoginInterceptor())
+        registry.addInterceptor(new LoginInterceptor(jwtService))
                 .order(1)
                 .addPathPatterns("/", "/seats", "/reservations");
     }

--- a/src/main/java/com/kboticketing/kboticketing/config/WebConfig.java
+++ b/src/main/java/com/kboticketing/kboticketing/config/WebConfig.java
@@ -4,6 +4,7 @@ import com.kboticketing.kboticketing.interceptor.LoginInterceptor;
 import com.kboticketing.kboticketing.service.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -12,6 +13,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  */
 @Configuration
 @RequiredArgsConstructor
+@Profile("!test")
 public class WebConfig implements WebMvcConfigurer {
 
     private final JwtService jwtService;

--- a/src/main/java/com/kboticketing/kboticketing/controller/UserController.java
+++ b/src/main/java/com/kboticketing/kboticketing/controller/UserController.java
@@ -1,11 +1,14 @@
 package com.kboticketing.kboticketing.controller;
 
 import com.kboticketing.kboticketing.dto.EmailRequestDto;
+import com.kboticketing.kboticketing.dto.SignInDto;
 import com.kboticketing.kboticketing.dto.UserDto;
 import com.kboticketing.kboticketing.dto.VerificationCodeDto;
+import com.kboticketing.kboticketing.response.CommonResponse;
 import com.kboticketing.kboticketing.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +35,11 @@ public class UserController {
     @PostMapping("verification-code-validation")
     public void checkVerificationCode(@RequestBody @Valid VerificationCodeDto verificationCodeDto) {
         userService.checkVerificationCode(verificationCodeDto);
+    }
+
+    @PostMapping("sign-in")
+    public ResponseEntity<CommonResponse> signIn(@RequestBody @Valid SignInDto signInDto) {
+        return ResponseEntity.ok(CommonResponse.ok(userService.signIn(signInDto)));
     }
 }
 

--- a/src/main/java/com/kboticketing/kboticketing/domain/User.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/User.java
@@ -2,7 +2,6 @@ package com.kboticketing.kboticketing.domain;
 
 import com.kboticketing.kboticketing.enums.Role;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
@@ -12,13 +11,30 @@ import java.time.LocalDateTime;
  */
 @Getter
 @ToString
-@RequiredArgsConstructor
 public class User {
 
-    private long userId;
+    private int userId;
     private final String name;
     private final String email;
     private final String password;
     private final Role role;
     private final LocalDateTime createdAt;
+
+    public User(String name, String email, String password, Role role, LocalDateTime createdAt) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.createdAt = createdAt;
+    }
+
+    public User(int userId, String name, String email, String password, Role role,
+        LocalDateTime createdAt) {
+        this.userId = userId;
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/kboticketing/kboticketing/dto/SignInDto.java
+++ b/src/main/java/com/kboticketing/kboticketing/dto/SignInDto.java
@@ -1,0 +1,23 @@
+package com.kboticketing.kboticketing.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author hazel
+ */
+@Getter
+@RequiredArgsConstructor
+public class SignInDto {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 아닙니다.")
+    private final String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*?_]).{8,20}", message = "비밀번호는 영문자와 숫자,특수문자가 최소 1개 이상씩 포함된 8~20자로 입력해주세요.")
+    private final String password;
+}

--- a/src/main/java/com/kboticketing/kboticketing/exception/ErrorCode.java
+++ b/src/main/java/com/kboticketing/kboticketing/exception/ErrorCode.java
@@ -24,7 +24,13 @@ public enum ErrorCode {
     MAXIMUM_SEAT_EXCEED(HttpStatus.BAD_REQUEST, "예매 가능한 좌석 수량을 초과했습니다."),
     MAXIMUM_RESERVATION_EXCEED(HttpStatus.BAD_REQUEST, "한 경기당 예매 가능한 횟수를 초과했습니다."),
     RESERVED_SEAT(HttpStatus.BAD_REQUEST, "이미 예매된 좌석입니다."),
+
+    /* 403 : 권한 없음 */
     LOGIN_REQUIRED(HttpStatus.BAD_REQUEST, "로그인을 먼저 진행해주세요."),
+    NOT_REGISTERED(HttpStatus.FORBIDDEN, "회원가입한 유저가 아닙니다."),
+    WRONG_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 틀립니다."),
+    INVALID_TOKEN(HttpStatus.FORBIDDEN, "유효한 토큰이 아닙니다."),
+    EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "만료된 토큰입니다."),
 
     /* 500 INTERNAL_SERVER_ERROR : 서버 오류 */
     FAIL_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다."),

--- a/src/main/java/com/kboticketing/kboticketing/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/kboticketing/kboticketing/interceptor/LoginInterceptor.java
@@ -1,24 +1,28 @@
-package com.kboticketing.kboticketing.Interceptor;
+package com.kboticketing.kboticketing.interceptor;
 
 import com.kboticketing.kboticketing.exception.CustomException;
 import com.kboticketing.kboticketing.exception.ErrorCode;
+import com.kboticketing.kboticketing.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
- * todo 수정 예정
- *
  * @author hazel
  */
 
 @Slf4j
+@RequiredArgsConstructor
 public class LoginInterceptor implements HandlerInterceptor {
+
+    private final JwtService jwtService;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
         Object handler) {
+
         String requestURI = request.getRequestURI();
         log.info("[interceptor] requestURI : " + requestURI);
 
@@ -28,7 +32,11 @@ public class LoginInterceptor implements HandlerInterceptor {
         }
 
         String[] splitToken = token.split(" ");
-        String userId = splitToken[1];
+        if (!token.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String userId = jwtService.validateJwt(splitToken[1]);
         request.setAttribute("userId", userId);
         return true;
     }

--- a/src/main/java/com/kboticketing/kboticketing/service/JwtService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/JwtService.java
@@ -1,0 +1,66 @@
+package com.kboticketing.kboticketing.service;
+
+import com.kboticketing.kboticketing.exception.CustomException;
+import com.kboticketing.kboticketing.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.Calendar;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author hazel
+ */
+@Service("JwtService")
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+    private final static String issuer = "kbo-ticketing";
+
+    public String generateJwt(int userId) {
+
+        Calendar calendar = Calendar.getInstance();
+        Date now = calendar.getTime();
+        calendar.add(Calendar.DAY_OF_YEAR, 1);
+        Date oneDayLater = calendar.getTime();
+
+        return Jwts.builder()
+                   .header()
+                   .and()
+                   .issuer(issuer)
+                   .subject(String.valueOf(userId))
+                   .issuedAt(now)
+                   .expiration(oneDayLater)
+                   .signWith(getSigningKey())
+                   .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtSecret));
+    }
+
+    public String validateJwt(String jwt) {
+
+        try {
+            Jws<Claims> claimsJws = Jwts.parser()
+                                        .verifyWith(getSigningKey())
+                                        .build()
+                                        .parseSignedClaims(jwt);
+            return claimsJws.getPayload()
+                            .get("sub", String.class);
+
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException e) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/utils/PasswordUtils.java
+++ b/src/main/java/com/kboticketing/kboticketing/utils/PasswordUtils.java
@@ -7,9 +7,14 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
  */
 public class PasswordUtils {
 
-    private static final BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+    // todo bean으로 수정
+    static BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
 
     public static String encryptPassword(String password) {
         return bCryptPasswordEncoder.encode(password);
+    }
+
+    public static Boolean matchPassword(String rawPassword, String encodedPassword) {
+        return bCryptPasswordEncoder.matches(rawPassword, encodedPassword);
     }
 }

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -4,14 +4,13 @@
 
 <mapper namespace="com.kboticketing.kboticketing.dao.UserMapper">
   <insert id="insert" parameterType="com.kboticketing.kboticketing.domain.User">
-    INSERT INTO users (name, `email`, password, role, created_at)
+    INSERT INTO users (name, email, password, role, created_at)
     VALUES (#{name}, #{email}, #{password}, #{role}, #{createdAt})
   </insert>
 
   <select id="selectByEmail" resultType="com.kboticketing.kboticketing.domain.User">
-    SELECT name, email, password, role, created_at
+    SELECT user_id, name, email, password, role, created_at
     FROM users
     WHERE email = #{email}
   </select>
-
 </mapper>

--- a/src/test/java/com/kboticketing/kboticketing/controller/ReservationControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/ReservationControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -24,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
  */
 @WebMvcTest(ReservationController.class)
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class ReservationControllerTest {
 
     @Autowired
@@ -43,14 +45,16 @@ class ReservationControllerTest {
         seatArr.add(seat2);
         ReservationDto reservationDto = new ReservationDto(seatArr);
 
-        willDoNothing().given(reservationService)
-                       .reserveSeats(any(ReservationDto.class), any(Integer.class));
+        willDoNothing()
+            .given(reservationService)
+            .reserveSeats(any(ReservationDto.class), any(Integer.class));
 
         String json = new ObjectMapper().writeValueAsString(reservationDto);
 
         //when,then
         mockMvc.perform(post("/reservations")
                    .content(json)
+                   .requestAttr("userId", 1)
                    .contentType(MediaType.APPLICATION_JSON))
                .andExpect(status().isOk());
     }

--- a/src/test/java/com/kboticketing/kboticketing/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/ScheduleControllerTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -25,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
  */
 @WebMvcTest(ScheduleController.class)
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class ScheduleControllerTest {
 
     @Autowired

--- a/src/test/java/com/kboticketing/kboticketing/controller/SeatControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/SeatControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
  */
 @WebMvcTest(SeatController.class)
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class SeatControllerTest {
 
     @Autowired
@@ -83,6 +85,7 @@ class SeatControllerTest {
         //when,then
         mockMvc.perform(post("/seats")
                    .content(json)
+                   .requestAttr("userId", 1)
                    .contentType(MediaType.APPLICATION_JSON))
                .andExpect(status().isOk());
     }

--- a/src/test/java/com/kboticketing/kboticketing/controller/TeamControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/TeamControllerTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 
@@ -24,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
  */
 @WebMvcTest(TeamController.class)
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class TeamControllerTest {
 
     @Autowired

--- a/src/test/java/com/kboticketing/kboticketing/controller/UserControllerTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/controller/UserControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @WebMvcTest(UserController.class)
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 public class UserControllerTest {
 
     @Autowired

--- a/src/test/java/com/kboticketing/kboticketing/interceptor/LoginInterceptorTest.java
+++ b/src/test/java/com/kboticketing/kboticketing/interceptor/LoginInterceptorTest.java
@@ -1,0 +1,89 @@
+package com.kboticketing.kboticketing.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.kboticketing.kboticketing.exception.CustomException;
+import com.kboticketing.kboticketing.exception.ErrorCode;
+import com.kboticketing.kboticketing.service.JwtService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author hazel
+ */
+@ExtendWith(MockitoExtension.class)
+public class LoginInterceptorTest {
+
+    @InjectMocks
+    private LoginInterceptor loginInterceptor;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private MockHttpServletRequest request;
+
+    @Mock
+    private MockHttpServletResponse response;
+
+    @Test
+    @DisplayName("[SUCCESS]로그인 인터셉터 테스트")
+    public void preHandleTest() {
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+
+        //given
+        request.addHeader("Authorization", "Bearer validToken");
+        BDDMockito.given(jwtService.validateJwt("validToken"))
+                  .willReturn("1");
+
+        //when
+        boolean result = loginInterceptor.preHandle(request, response, null);
+
+        //then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("[FAIL]로그인 인터셉터 토큰 확인 테스트")
+    public void preHandleTokenCheckTest() {
+
+        //given
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        request.addHeader("", "");
+
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+            () -> loginInterceptor.preHandle(request, response, null));
+
+        //then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.LOGIN_REQUIRED);
+    }
+
+
+    @Test
+    @DisplayName("[FAIL]로그인 인터셉터 토큰 검증 테스트")
+    public void preHandleJwtValidateTest() {
+
+        //given
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        request.addHeader("Authorization", " ");
+
+        //when
+        CustomException customException = assertThrows(CustomException.class,
+            () -> loginInterceptor.preHandle(request, response, null));
+
+        //then
+        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #35 

## 작업 내용
- `JwtService` 구현
- `LoginIntercpetor`에서 토큰 검증하도록 구현 
- `LoginInterceptor` `unit test` 추가
- 로그인 `controller`, `service` 레이어 `unit test` 추가 
- `controller` 레이어 `unit test` 에서 `WebConfig`가 빈으로 등록되지 않도록 수정

## 참고사항

