### PR TITLE
[#44] Cache 적용으로 읽기 성능 최적화하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     //jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.12.5'
+    // spring-boot-starter-cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kboticketing/kboticketing/config/RedisCacheConfig.java
+++ b/src/main/java/com/kboticketing/kboticketing/config/RedisCacheConfig.java
@@ -1,0 +1,30 @@
+package com.kboticketing.kboticketing.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * @author hazel
+ */
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                                      .disableCachingNullValues()
+                                      .serializeKeysWith(
+                                          RedisSerializationContext.SerializationPair.fromSerializer(
+                                              new StringRedisSerializer())
+                                      )
+                                      .serializeValuesWith(
+                                          RedisSerializationContext.SerializationPair.fromSerializer(
+                                              new GenericJackson2JsonRedisSerializer()));
+    }
+}

--- a/src/main/java/com/kboticketing/kboticketing/config/RedisConfig.java
+++ b/src/main/java/com/kboticketing/kboticketing/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 /**
@@ -39,9 +40,10 @@ public class RedisConfig {
         RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
-        // 일반적인 key:value의 경우 직렬화 기본 (JdkSerializationRedisSerializer)
+        //String으로 직렬화
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        //JSON으로 직렬화
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
     }

--- a/src/main/java/com/kboticketing/kboticketing/domain/ScheduleInfo.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/ScheduleInfo.java
@@ -1,17 +1,28 @@
 package com.kboticketing.kboticketing.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author hazel
  */
 @Getter
-@RequiredArgsConstructor
 public class ScheduleInfo {
 
     private final Integer scheduleId;
     private final String scheduleName;
     private final String date;
     private final String stadiumName;
+
+    @JsonCreator
+    public ScheduleInfo(@JsonProperty("scheduleId") Integer scheduleId,
+        @JsonProperty("scheduleName") String scheduleName,
+        @JsonProperty("date") String date,
+        @JsonProperty("stadiumName") String stadiumName) {
+        this.scheduleId = scheduleId;
+        this.scheduleName = scheduleName;
+        this.date = date;
+        this.stadiumName = stadiumName;
+    }
 }

--- a/src/main/java/com/kboticketing/kboticketing/domain/ScheduleTeam.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/ScheduleTeam.java
@@ -1,12 +1,12 @@
 package com.kboticketing.kboticketing.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author hazel
  */
-@RequiredArgsConstructor
 @Getter
 public class ScheduleTeam {
 
@@ -14,4 +14,14 @@ public class ScheduleTeam {
     private final String scheduleName;
     private final String stadiumName;
     private final String date;
+
+    @JsonCreator
+    public ScheduleTeam(@JsonProperty("scheduleId") Integer scheduleId,
+        @JsonProperty("scheduleName") String scheduleName,
+        @JsonProperty("stadiumName") String stadiumName, @JsonProperty("date") String date) {
+        this.scheduleId = scheduleId;
+        this.scheduleName = scheduleName;
+        this.stadiumName = stadiumName;
+        this.date = date;
+    }
 }

--- a/src/main/java/com/kboticketing/kboticketing/domain/SeatGrade.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/SeatGrade.java
@@ -1,18 +1,27 @@
 package com.kboticketing.kboticketing.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author hazel
  */
 @Getter
-@RequiredArgsConstructor
 @EqualsAndHashCode
 public class SeatGrade {
 
     private final Integer seatGradeId;
     private final String seatGradeName;
     private final String seatCount;
+
+    @JsonCreator
+    public SeatGrade(@JsonProperty("seatGradeId") Integer seatGradeId,
+        @JsonProperty("seatGradeName") String seatGradeName,
+        @JsonProperty("seatCount") String seatCount) {
+        this.seatGradeId = seatGradeId;
+        this.seatGradeName = seatGradeName;
+        this.seatCount = seatCount;
+    }
 }

--- a/src/main/java/com/kboticketing/kboticketing/domain/Team.java
+++ b/src/main/java/com/kboticketing/kboticketing/domain/Team.java
@@ -1,15 +1,21 @@
 package com.kboticketing.kboticketing.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author hazel
  */
-@RequiredArgsConstructor
 @Getter
 public class Team {
 
     private final Integer teamId;
     private final String name;
+
+    @JsonCreator
+    public Team(@JsonProperty("teamId") Integer teamId, @JsonProperty("name") String name) {
+        this.teamId = teamId;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/kboticketing/kboticketing/dto/ScheduleQueryParamDto.java
+++ b/src/main/java/com/kboticketing/kboticketing/dto/ScheduleQueryParamDto.java
@@ -1,12 +1,16 @@
 package com.kboticketing.kboticketing.dto;
 
 import java.time.LocalDateTime;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * @author hazel
  */
 @Getter
+@EqualsAndHashCode
+@ToString
 public class ScheduleQueryParamDto {
 
     private final Integer teamId;

--- a/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
@@ -7,6 +7,7 @@ import com.kboticketing.kboticketing.domain.SeatGradeBySchedule;
 import com.kboticketing.kboticketing.dto.ScheduleQueryParamDto;
 import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -18,6 +19,7 @@ public class ScheduleService {
 
     private final ScheduleMapper scheduleMapper;
 
+    @Cacheable(value = "schedules/", key = "#scheduleQueryParamDto.toString()")
     public ArrayList<ScheduleTeam> getSchedules(ScheduleQueryParamDto scheduleQueryParamDto) {
         return scheduleMapper.selectSchedules(scheduleQueryParamDto);
     }

--- a/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/ScheduleService.java
@@ -24,6 +24,7 @@ public class ScheduleService {
         return scheduleMapper.selectSchedules(scheduleQueryParamDto);
     }
 
+    @Cacheable(value = "schedules/", key = "#id")
     public ScheduleInfo getSchedule(String id) {
         return scheduleMapper.selectInfo(id);
     }

--- a/src/main/java/com/kboticketing/kboticketing/service/SeatService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/SeatService.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,7 @@ public class SeatService {
         return new ReservationSeatDto(reservedSeat);
     }
 
+    @Cacheable(value = "seat-grades/", key = "#id")
     public SeatGrade getSeatGrade(String id) {
         return seatMapper.selectSeatGrade(id);
     }

--- a/src/main/java/com/kboticketing/kboticketing/service/TeamService.java
+++ b/src/main/java/com/kboticketing/kboticketing/service/TeamService.java
@@ -4,6 +4,7 @@ import com.kboticketing.kboticketing.dao.TeamMapper;
 import com.kboticketing.kboticketing.domain.Team;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -15,6 +16,7 @@ public class TeamService {
 
     private final TeamMapper teamMapper;
 
+    @Cacheable(value = "teams/")
     public List<Team> getTeams() {
         return teamMapper.selectTeams();
     }


### PR DESCRIPTION
## 관련 이슈
- #44
- #21 

## 작업 내용
- `spring-boot-starter-cache` 의존성 추가 
- 팀 목록 조회, 경기 목록 조회, 경기 조회, 좌석 등급 조회 시 Redis에 `cache-aside` 방식으로 캐싱하도록 수정 

## 참고사항

## 궁금한 점 🤔


